### PR TITLE
fix "xah-show-in-desktop: ShellExecute failed:

### DIFF
--- a/xah-fly-keys.el
+++ b/xah-fly-keys.el
@@ -2630,7 +2630,7 @@ Version 2018-09-29"
   (let (($path (if (buffer-file-name) (buffer-file-name) default-directory )))
     (cond
      ((string-equal system-type "windows-nt")
-      (w32-shell-execute "explore" (replace-regexp-in-string "/" "\\" $path t t)))
+      (w32-shell-execute "open" (replace-regexp-in-string "/" "\\" $path t t)))
      ((string-equal system-type "darwin")
       (if (eq major-mode 'dired-mode)
           (let (($files (dired-get-marked-files )))


### PR DESCRIPTION
in win10 
xah-show-in-desktop: ShellExecute failed: 没有应用程序与此操作的指定文件有关联。